### PR TITLE
Bump version to 1.2

### DIFF
--- a/hashids.nimble
+++ b/hashids.nimble
@@ -1,6 +1,6 @@
 [Package]
 name = "hashids"
-version = "1.1"
+version = "1.2"
 author = "Adam Chesak"
 description = "Nim implementation of Hashids"
 license = "MIT"


### PR DESCRIPTION
- Fixes Nim 0.19.0 incompatibility.
- Require Nim 0.19.0.